### PR TITLE
Adds .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 src
+.babelrc


### PR DESCRIPTION
This avoids conflicts for projects using Babel 6+, as `redux-analytics` is using Babel 5.
